### PR TITLE
Use new state shape and note about backend plugin tree shaking

### DIFF
--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -16,6 +16,7 @@
 // Above would add uploaded plugin to backend_plugin table and bind it
 
 import { BackendPlugins } from '@backendPlugins';
+// Tree shaking working
 import zipObject from 'lodash/zipObject';
 
 // TODO Should come from settings

--- a/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
+++ b/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
@@ -51,7 +51,7 @@ const StockDonorEditInput: StockDonorEditPlugin = ({ stockLine, events }) => {
           value={donor}
           onChange={e => {
             setDonor(e.target.value);
-            events.setIsDirty(true);
+            events.setState({ isDirty: false });
           }}
         />
       }


### PR DESCRIPTION
Please see this PR for documentation and updates https://github.com/msupply-foundation/open-msupply/pull/6485, which should work with this PR

Use new state shape and note about backend plugin tree shaking