### PR TITLE
Use-store-preference-in-backend-plugin-example

### DIFF
--- a/backend/latest/package.json
+++ b/backend/latest/package.json
@@ -4,7 +4,8 @@
     "omSupplyPlugin": {
         "target": "backend",
         "types": [
-            "AMC"
+            "AMC",
+            "TRANSFORM_REQUISITION_LINES"
         ],
         "variant_type": "BOA_JS"
     },

--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -22,6 +22,7 @@ import zipObject from 'lodash/zipObject';
 // TODO Should come from settings
 const DAY_LOOKBACK = 800;
 const DAYS_IN_MONTH = 30;
+const MONTHS_LEAD_TIME = 3;
 
 const plugins: BackendPlugins = {
   average_monthly_consumption: ({ store_id, item_ids }) => {
@@ -59,6 +60,18 @@ const plugins: BackendPlugins = {
     });
 
     return response;
+  },
+  transform_requisition_lines: ({ lines, requisition }) => {
+    return {
+      transformed_lines: lines.map(line => {
+        const max_quantity =
+          line.average_monthly_consumption *
+          (requisition.max_months_of_stock + MONTHS_LEAD_TIME);
+        const difference = max_quantity - line.available_stock_on_hand;
+        const suggested_quantity = difference < 0 ? 0 : difference;
+        return { ...line, suggested_quantity };
+      }),
+    };
   },
 };
 

--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -16,6 +16,7 @@
 // Above would add uploaded plugin to backend_plugin table and bind it
 
 import { BackendPlugins } from '@backendPlugins';
+// Tree shaking working
 import zipObject from 'lodash/zipObject';
 
 // TODO Should come from settings

--- a/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
+++ b/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   BasicTextInput,
   InputWithLabelRow,

--- a/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
+++ b/frontend/latest/src/StockDonor/StockDonorEditInput.tsx
@@ -51,7 +51,7 @@ const StockDonorEditInput: StockDonorEditPlugin = ({ stockLine, events }) => {
           value={donor}
           onChange={e => {
             setDonor(e.target.value);
-            events.setIsDirty(true);
+            events.setState({ isDirty: false });
           }}
         />
       }

--- a/frontend/latest/src/StockDonor/api/operations.generated.ts
+++ b/frontend/latest/src/StockDonor/api/operations.generated.ts
@@ -4,12 +4,14 @@ import { GraphQLClient, RequestOptions } from 'graphql-request';
 import gql from 'graphql-tag';
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 export type PluginDataQueryVariables = Types.Exact<{
+  pluginCode: Types.Scalars['String']['input'];
   storeId: Types.Scalars['String']['input'];
   stockLineIds?: Types.InputMaybe<Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input']>;
+  dataIdentifier: Types.Scalars['String']['input'];
 }>;
 
 
-export type PluginDataQuery = { __typename: 'Queries', pluginData: { __typename: 'PluginDataConnector', nodes: Array<{ __typename: 'PluginDataNode', id: string, data: string, pluginCode: string, relatedRecordId: string }> } };
+export type PluginDataQuery = { __typename: 'Queries', pluginData: { __typename: 'PluginDataConnector', nodes: Array<{ __typename: 'PluginDataNode', id: string, data: string, stockLineId?: string | null }> } };
 
 export type InsertPluginDataMutationVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
@@ -29,20 +31,18 @@ export type UpdatePluginDataMutation = { __typename: 'Mutations', updatePluginDa
 
 
 export const PluginDataDocument = gql`
-    query pluginData($storeId: String!, $stockLineIds: [String!]) {
+    query pluginData($pluginCode: String!, $storeId: String!, $stockLineIds: [String!], $dataIdentifier: String!) {
   pluginData(
+    pluginCode: $pluginCode
     storeId: $storeId
-    type: STOCK_LINE
-    filter: {relatedRecordId: {equalAny: $stockLineIds}}
+    filter: {dataIdentifier: {equalTo: $dataIdentifier}, relatedRecordId: {equalAny: $stockLineIds}}
   ) {
+    __typename
     ... on PluginDataConnector {
-      __typename
       nodes {
-        __typename
         id
         data
-        pluginCode
-        relatedRecordId
+        stockLineId: relatedRecordId
       }
     }
   }

--- a/frontend/latest/src/StockDonor/api/operations.graphql
+++ b/frontend/latest/src/StockDonor/api/operations.graphql
@@ -1,22 +1,27 @@
-query pluginData($storeId: String!, $stockLineIds: [String!]) {
+query pluginData(
+  $pluginCode: String!
+  $storeId: String!
+  $stockLineIds: [String!]
+  $dataIdentifier: String!
+) {
   pluginData(
+    pluginCode: $pluginCode
     storeId: $storeId
-    type: STOCK_LINE
-    filter: { relatedRecordId: { equalAny: $stockLineIds } }
+    filter: {
+      dataIdentifier: { equalTo: $dataIdentifier }
+      relatedRecordId: { equalAny: $stockLineIds }
+    }
   ) {
+    __typename
     ... on PluginDataConnector {
-      __typename
       nodes {
-        __typename
         id
         data
-        pluginCode
-        relatedRecordId
+        stockLineId: relatedRecordId
       }
     }
   }
 }
-
 mutation insertPluginData($storeId: String!, $input: InsertPluginDataInput!) {
   insertPluginData(input: $input, storeId: $storeId) {
     ... on PluginDataNode {


### PR DESCRIPTION
Sorry there are changes here that are not part of this PR, i can't quite base in open-msupply repository to the right branch since I am working off a fork with stacked PRs (once https://github.com/msupply-foundation/open-msupply-plugins/pull/7 is merged it would be easier).

The only change is this commit: [696bb9c](https://github.com/msupply-foundation/open-msupply-plugins/pull/9/commits/696bb9c9add83f0eb9dcf79f08fd99ec864966b4)

Related omsupply PR: https://github.com/msupply-foundation/open-msupply/pull/6649