### PR TITLE
Dashboard plugin examples pt 2

### DIFF
--- a/frontend/latest/src/Dashboard/InboundShipmentCustomStats.tsx
+++ b/frontend/latest/src/Dashboard/InboundShipmentCustomStats.tsx
@@ -31,12 +31,8 @@ const StatisticsPanel = ({ panelContext }: { panelContext: string }) => {
   ) : null;
 };
 
-interface OrderingStatsProps {
-  panelContext: string;
-}
-
-export const OrderingStats = ({ panelContext }: OrderingStatsProps) => {
-  // determine both the widget and panel context to render the stat in the correct place
+export const Component = ({ panelContext }: { panelContext: string }) => {
+  // Only render in the replenishment widget + inbound shipments panel
   // can be a plugin or core dashboard widget/panel
   if (panelContext !== 'replenishment-inbound-shipments') {
     return null;
@@ -51,4 +47,9 @@ export const OrderingStats = ({ panelContext }: OrderingStatsProps) => {
   );
 };
 
-export default OrderingStats;
+// Optional: Static property defines the core statistics to hide when this plugin is active
+// Will only hide stats in the defined widget and panel context
+export const hiddenStats = [
+  'replenishment-inbound-shipments-today',
+  'replenishment-inbound-shipments-this-week',
+];

--- a/frontend/latest/src/Dashboard/InboundShipmentCustomStats.tsx
+++ b/frontend/latest/src/Dashboard/InboundShipmentCustomStats.tsx
@@ -48,7 +48,6 @@ export const Component = ({ panelContext }: { panelContext: string }) => {
 };
 
 // Optional: Static property defines the core statistics to hide when this plugin is active
-// Will only hide stats in the defined widget and panel context
 export const hiddenStats = [
   'replenishment-inbound-shipments-today',
   'replenishment-inbound-shipments-this-week',

--- a/frontend/latest/src/Dashboard/README.md
+++ b/frontend/latest/src/Dashboard/README.md
@@ -1,0 +1,57 @@
+# OMS Dashboard Plugin Examples
+
+The core dashboard can be extended with plugins to add widgets, panels, or statistics, and by hiding existing core dashboard items to create the effect of replacement.
+
+## Plugin Structure
+
+Panel and statistic plugin components receive the context prop of it's parent level. Widgets are top-level and do not require a parent context.
+
+Each exported object must include a `Component` property and may include an array to hide core dashboard items by context.
+
+The `dashboard` property in the `Plugins` type interface defines how plugins can extend the dashboard at three levels:
+
+- **widget**: Each object provides:
+  - `Component`: The React component to render as a dashboard widget.
+  - `hiddenWidgets?`: (optional) Array of context strings specifying core widgets to hide.
+
+- **panel**: Each object provides:
+  - `Component`: The React component to render as a dashboard panel. Receives a `widgetContext` prop.
+  - `hiddenPanels?`: (optional) Array of context strings specifying core panels to hide.
+
+- **statistic**: Each object provides:
+  - `Component`: The React component to render as a dashboard statistic. Receives a `panelContext` prop.
+  - `hiddenStats?`: (optional) Array of context strings specifying core statistics to hide.
+
+## Rendering Plugin Components
+
+Create a component that receives the relevant parent context prop. The component will only render if the defined context string (eg 'replenishment-inbound-shipments') matches the context prop, ensuring the plugin appears in the correct place in the dashboard hierarchy.
+
+When creating nested items, export just the higher-level component (eg a panel) through the plugin interface. Child components (eg statistics) can be defined inline or imported to the parent. The order of components within the parent component determines their order in the plugin, which will always appear after core items.
+
+```typescript
+export const Component = ({ panelContext }: { panelContext: string }) => {
+
+  if (panelContext !== 'replenishment-inbound-shipments') {
+    return null;
+  }
+
+  return (
+    <ThemeProviderProxy>
+      <QueryClientProviderProxy>
+        <StatisticsPanel panelContext={panelContext} />
+      </QueryClientProviderProxy>
+    </ThemeProviderProxy>
+  );
+};
+
+```
+
+### Hiding Core Items
+
+To hide core dashboard items, provide the relevant context strings in the `hiddenWidgets`, `hiddenPanels`, or `hiddenStats` static property arrays. The dashboard will filter out core items matching these contexts.
+
+Items can only be hidden if they match the type of the plugin item (eg a panel plugin can only hide core panels).
+
+```typescript
+export const hiddenStats = ['core-stat-context-to-hide'];
+```

--- a/frontend/latest/src/Dashboard/ReplenishmentPanels.tsx
+++ b/frontend/latest/src/Dashboard/ReplenishmentPanels.tsx
@@ -44,7 +44,7 @@ const ShipmentsPanel = ({ widgetContext }: ReplenishmentPanelsProps) => {
   );
 };
 
-const ReplenishmentPanels = ({ widgetContext }: ReplenishmentPanelsProps) => {
+export const Component = ({ widgetContext }: ReplenishmentPanelsProps) => {
   // defines the widget the component will render into
   // will render only in widgets with context 'replenishment'
   if (widgetContext !== 'replenishment') return null;
@@ -59,4 +59,5 @@ const ReplenishmentPanels = ({ widgetContext }: ReplenishmentPanelsProps) => {
   );
 };
 
-export default ReplenishmentPanels;
+// Optional: Static property defines the core panels to hide when this plugin is active
+export const hiddenPanels = ['replenishment-internal-orders'];

--- a/frontend/latest/src/Dashboard/SyncStatus.tsx
+++ b/frontend/latest/src/Dashboard/SyncStatus.tsx
@@ -3,15 +3,21 @@ import {
   QueryClientProviderProxy,
   ThemeProviderProxy,
 } from '@openmsupply-client/common';
-import { PropsWithChildrenOnly } from '@common/types';
 import SyncStatusWidget from './SyncStatusWidget';
 
-const SyncStatus: React.FC<PropsWithChildrenOnly> = () => (
-  <ThemeProviderProxy>
-    <QueryClientProviderProxy>
-      <SyncStatusWidget />
-    </QueryClientProviderProxy>
-  </ThemeProviderProxy>
-);
+export interface SyncWidgetProps {
+  widgetContext: string;
+}
 
-export default SyncStatus;
+export const Component = () => {
+  return (
+    <ThemeProviderProxy>
+      <QueryClientProviderProxy>
+        <SyncStatusWidget />
+      </QueryClientProviderProxy>
+    </ThemeProviderProxy>
+  );
+};
+
+// Optional: Static property defines the core widgets to hide when this plugin is active
+export const hiddenWidgets = ['stock'];

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -2,7 +2,7 @@ import { Plugins } from '@openmsupply-client/common';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
 import SyncStatus from './Dashboard/SyncStatus';
 import ReplenishmentPanels from './Dashboard/ReplenishmentPanels';
-import OrderingStats from './Dashboard/InboundShipmentCustomStats';
+import * as OrderingStats from './Dashboard/InboundShipmentCustomStats';
 import StockDonorEdit from './StockDonor/StockDonorEdit';
 import * as stockDonor from './StockDonor/StockDonorColumn';
 import * as aggregateAmc from './AggregateAmc/AggregateAmcColumn';
@@ -13,7 +13,7 @@ const ReplenishmentAndSyncStatus: Plugins = {
   dashboard: {
     widget: [SyncStatus],
     panel: [ReplenishmentPanels],
-    statistic: [OrderingStats],
+    statistic: [OrderingStats, { Component: () => null, hiddenStats: [] }],
   },
   stockLine: {
     tableStateLoader: [stockDonor.StateLoader],

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -1,7 +1,7 @@
 import { Plugins } from '@openmsupply-client/common';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
 import SyncStatus from './Dashboard/SyncStatus';
-import ReplenishmentPanels from './Dashboard/ReplenishmentPanels';
+import * as ReplenishmentPanels from './Dashboard/ReplenishmentPanels';
 import * as OrderingStats from './Dashboard/InboundShipmentCustomStats';
 import StockDonorEdit from './StockDonor/StockDonorEdit';
 import * as stockDonor from './StockDonor/StockDonorColumn';
@@ -12,7 +12,7 @@ const ReplenishmentAndSyncStatus: Plugins = {
   inboundShipmentAppBar: [ShippingStatus],
   dashboard: {
     widget: [SyncStatus],
-    panel: [ReplenishmentPanels],
+    panel: [ReplenishmentPanels, { Component: () => null, hiddenPanels: [] }],
     statistic: [OrderingStats, { Component: () => null, hiddenStats: [] }],
   },
   stockLine: {

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -1,6 +1,6 @@
 import { Plugins } from '@openmsupply-client/common';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
-import SyncStatus from './Dashboard/SyncStatus';
+import * as SyncStatus from './Dashboard/SyncStatus';
 import * as ReplenishmentPanels from './Dashboard/ReplenishmentPanels';
 import * as OrderingStats from './Dashboard/InboundShipmentCustomStats';
 import StockDonorEdit from './StockDonor/StockDonorEdit';
@@ -11,7 +11,7 @@ import { Info } from './AggregateAmc/AggregateAmcInfo';
 const ReplenishmentAndSyncStatus: Plugins = {
   inboundShipmentAppBar: [ShippingStatus],
   dashboard: {
-    widget: [SyncStatus],
+    widget: [SyncStatus, { Component: () => null, hiddenWidgets: [] }],
     panel: [ReplenishmentPanels, { Component: () => null, hiddenPanels: [] }],
     statistic: [OrderingStats, { Component: () => null, hiddenStats: [] }],
   },


### PR DESCRIPTION
Part 2 - examples for https://github.com/msupply-foundation/open-msupply/pull/10293

Optionally configure core stats to hide when using a plugin stat/stats. Essentially to replace a core stat with a plugin stat, though it will allow one or many of each

This is done per panel, using the widget/panel/stat contexts introduced in part 1.

~Only addresses hiding stats at this stage, though this could be implemented to hide core panels or widgets later if required~
Updated to hide any core stat, panel or widget on the dashboard if the items context is provided in a plugin component of the same type