### PR TITLE
Demo plugin pages for new pages interface

### DIFF
--- a/frontend/latest/src/Pages/ReportingDailyPage.tsx
+++ b/frontend/latest/src/Pages/ReportingDailyPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Typography } from '@openmsupply-client/common';
+
+export const ReportingDailyPage: React.FC = () => (
+  <Box padding={3} display="flex" flexDirection="column" gap={1}>
+    <Typography variant="h5">Reporting / Daily</Typography>
+    <Typography variant="body1">
+      Bare-bones plugin page: no AppBar, Toolbar, or Footer chrome. The
+      surrounding host shell is left empty.
+    </Typography>
+  </Box>
+);

--- a/frontend/latest/src/Pages/ReportingDailyPage.tsx
+++ b/frontend/latest/src/Pages/ReportingDailyPage.tsx
@@ -1,3 +1,7 @@
+// Demo plugin page — illustrates the new `pages` slot in the open-mSupply plugin
+// infrastructure. See https://github.com/msupply-foundation/open-msupply/pull/11702
+// for the host-side implementation this page pairs with.
+
 import React from 'react';
 import { Box, Typography } from '@openmsupply-client/common';
 

--- a/frontend/latest/src/Pages/StockAgingPage.tsx
+++ b/frontend/latest/src/Pages/StockAgingPage.tsx
@@ -1,3 +1,7 @@
+// Demo plugin page — illustrates the new `pages` slot in the open-mSupply plugin
+// infrastructure. See https://github.com/msupply-foundation/open-msupply/pull/11702
+// for the host-side implementation this page pairs with.
+
 import React from 'react';
 import {
   AppBarButtonsPortal,

--- a/frontend/latest/src/Pages/StockAgingPage.tsx
+++ b/frontend/latest/src/Pages/StockAgingPage.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  AppBarButtonsPortal,
+  AppBarContentPortal,
+  AppFooterPortal,
+  Box,
+  ButtonWithIcon,
+  PrinterIcon,
+  Toolbar,
+  Typography,
+} from '@openmsupply-client/common';
+
+export const StockAgingPage: React.FC = () => (
+  <>
+    <AppBarButtonsPortal>
+      <ButtonWithIcon
+        label="Print"
+        onClick={() => window.print()}
+        Icon={<PrinterIcon />}
+      />
+    </AppBarButtonsPortal>
+    <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
+      <Typography variant="h5">Stock aging</Typography>
+    </AppBarContentPortal>
+    <Box display="flex" flexDirection="column" flex={1} padding={2}>
+      <Toolbar disableGutters>
+        <Typography variant="subtitle1">
+          Plugin-supplied page rendered inside the Inventory section.
+        </Typography>
+      </Toolbar>
+      <Box>Page body content goes here.</Box>
+    </Box>
+    <AppFooterPortal
+      Content={
+        <Box display="flex" alignItems="center" height={56} paddingX={2}>
+          <Typography variant="caption">
+            Stock aging plugin footer area.
+          </Typography>
+        </Box>
+      }
+    />
+  </>
+);

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -1,4 +1,5 @@
-import { Plugins } from '@openmsupply-client/common';
+import { Plugins, ReportsIcon } from '@openmsupply-client/common';
+import { AppRoute } from '@openmsupply-client/config';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
 import Replenishment from './Dashboard/Replenishment';
 import SyncStatus from './Dashboard/SyncStatus';
@@ -6,6 +7,8 @@ import StockDonorEdit from './StockDonor/StockDonorEdit';
 import * as stockDonor from './StockDonor/StockDonorColumn';
 import * as aggregateAmc from './AggregateAmc/AggregateAmcColumn';
 import { Info } from './AggregateAmc/AggregateAmcInfo';
+import { StockAgingPage } from './Pages/StockAgingPage';
+import { ReportingDailyPage } from './Pages/ReportingDailyPage';
 
 const ReplenishmentAndSyncStatus: Plugins = {
   inboundShipmentAppBar: [ShippingStatus],
@@ -21,6 +24,30 @@ const ReplenishmentAndSyncStatus: Plugins = {
     editViewField: [aggregateAmc.AggregateAmcEditView],
     editViewInfo: [Info],
   },
+  pages: [
+    {
+      route: 'stock-aging',
+      Component: StockAgingPage,
+      menu: {
+        label: { en: 'Stock aging', fr: "Vieillissement du stock" },
+        category: { type: 'existing', appRoute: AppRoute.Inventory },
+      },
+    },
+    {
+      route: 'daily',
+      Component: ReportingDailyPage,
+      menu: {
+        label: { en: 'Daily', fr: 'Quotidien' },
+        category: {
+          type: 'new',
+          key: 'reporting',
+          label: { en: 'Reporting', fr: 'Rapports' },
+          icon: ReportsIcon,
+          order: 500,
+        },
+      },
+    },
+  ],
 };
 
 export default ReplenishmentAndSyncStatus;

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -29,7 +29,7 @@ const ReplenishmentAndSyncStatus: Plugins = {
       route: 'stock-aging',
       Component: StockAgingPage,
       menu: {
-        label: { en: 'Stock aging', fr: "Vieillissement du stock" },
+        label: 'Stock aging',
         category: { type: 'existing', appRoute: AppRoute.Inventory },
       },
     },
@@ -37,11 +37,11 @@ const ReplenishmentAndSyncStatus: Plugins = {
       route: 'daily',
       Component: ReportingDailyPage,
       menu: {
-        label: { en: 'Daily', fr: 'Quotidien' },
+        label: 'Daily',
         category: {
           type: 'new',
           key: 'reporting',
-          label: { en: 'Reporting', fr: 'Rapports' },
+          label: 'Reporting',
           icon: ReportsIcon,
           order: 500,
         },


### PR DESCRIPTION
## Summary
Adds two demo plugin pages exercising the new `pages` slot introduced in [open-msupply#11702](https://github.com/msupply-foundation/open-msupply/pull/11702). Pair with the framework PR on the host side (linked from that PR).

- **Stock Aging** — full-chrome page using `AppBarButtonsPortal`, `AppBarContentPortal`, `Toolbar`, `AppFooterPortal`. Registered under the built-in Inventory category, so the link appears as a sub-item of the existing Inventory nav, and routes to `/inventory/stock-aging`.
- **Reporting / Daily** — minimal page, no chrome. Registered under a new top-level category `reporting`, demonstrating the new-category path: a fresh drawer section that other plugins can opt into by reusing the same `key`. Routes to `/reporting/daily`.

The pair illustrate both ends of the layout spectrum the new interface supports — full host shell integration via portals, or a blank-slate page.

## Test plan

- [ ] With the matching `open-msupply` branch checked out, `yarn start` shows two new menu items: "Stock aging" under Inventory and a new "Reporting" section containing "Daily"
- [ ] Both pages render their respective content at the URLs above
- [ ] Print button on Stock Aging triggers `window.print()`
- [ ] Existing plugin slots (Replenishment widget, SyncStatus widget, StockDonor, AggregateAmc, ShippingStatus) all still render
- [ ] `yarn build` succeeds for `frontend/latest`