### PR TITLE
Add plugin configuration example

### DIFF
--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -102,6 +102,8 @@ const plugins: BackendPlugins = {
             .filter(({ item_id }) => item_id === line.item_link_id)
             .reduce((acc, row) => acc + row.average_monthly_consumption, 0)
         ),
+        // Optional plugin-controlled timestamp; not used for AMC data.
+        datetime: null,
       })),
     };
   },

--- a/frontend/latest/src/Configuration/ConfigComponent.tsx
+++ b/frontend/latest/src/Configuration/ConfigComponent.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {
+  BasicTextInput,
+  Box,
+  Checkbox,
+  Typography,
+  Widget,
+} from '@openmsupply-client/common';
+import {
+  DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+  ExamplePluginConfig,
+} from './types';
+
+// Custom React configuration UI. Shipped via the `Component` slot of the
+// plugin's `configuration` field. The equivalent JSON Forms version is kept
+// as commented-out reference in ../plugin.tsx for plugin authors to compare.
+//
+// Demonstrates two things JSON Forms can't easily do:
+//   - bespoke composition (the live-preview pane below the form)
+//   - direct access to the host's component library, fully styled with the
+//     project's design system
+type Props = {
+  value: ExamplePluginConfig;
+  onChange: (next: ExamplePluginConfig) => void;
+};
+
+export const ExamplePluginConfigComponent = ({ value, onChange }: Props) => {
+  // Defensive: if the persisted blob is missing fields (older row, hand-edited
+  // DB, etc.), fall back to defaults so the form always has something to render.
+  const config: ExamplePluginConfig = {
+    ...DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+    ...value,
+  };
+
+  const patch = (next: Partial<ExamplePluginConfig>) =>
+    onChange({ ...config, ...next });
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Box display="flex" flexDirection="column" gap={2}>
+        <Box display="flex" alignItems="center" gap={1}>
+          <Checkbox
+            checked={config.enabled}
+            onChange={(_, checked) => patch({ enabled: checked })}
+          />
+          <Typography>Show Sync Status widget</Typography>
+        </Box>
+
+        <BasicTextInput
+          label="Sync widget title"
+          fullWidth
+          value={config.logPrefix}
+          onChange={e => patch({ logPrefix: e.target.value })}
+        />
+      </Box>
+
+      <Box>
+        <Typography variant="caption" color="gray.main">
+          Live preview
+        </Typography>
+        {config.enabled ? (
+          <Widget title={config.logPrefix || 'Sync widget title'}>
+            <Box padding={2}>
+              <Typography variant="body2" color="gray.dark">
+                Sync status content would render here on the dashboard.
+              </Typography>
+            </Box>
+          </Widget>
+        ) : (
+          <Typography variant="body2" color="gray.dark" sx={{ mt: 1 }}>
+            Widget is hidden — toggle &ldquo;Show Sync Status widget&rdquo; to
+            enable.
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/latest/src/Configuration/ConfigComponent.tsx
+++ b/frontend/latest/src/Configuration/ConfigComponent.tsx
@@ -12,10 +12,9 @@ import {
 } from './types';
 
 // Custom React configuration UI. Shipped via the `Component` slot of the
-// plugin's `configuration` field. The equivalent JSON Forms version is kept
-// as commented-out reference in ../plugin.tsx for plugin authors to compare.
+// plugin's `configuration` field (see ../plugin.tsx).
 //
-// Demonstrates two things JSON Forms can't easily do:
+// Demonstrates the freedom a custom component gives you:
 //   - bespoke composition (the live-preview pane below the form)
 //   - direct access to the host's component library, fully styled with the
 //     project's design system

--- a/frontend/latest/src/Configuration/index.ts
+++ b/frontend/latest/src/Configuration/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './usePluginConfiguration';
+export * from './ConfigComponent';

--- a/frontend/latest/src/Configuration/operations.generated.ts
+++ b/frontend/latest/src/Configuration/operations.generated.ts
@@ -1,0 +1,82 @@
+import * as Types from '@openmsupply-client/common';
+
+import { GraphQLClient, RequestOptions } from 'graphql-request';
+import gql from 'graphql-tag';
+type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
+export type ExamplePluginConfigurationQueryVariables = Types.Exact<{
+  pluginCode: Types.Scalars['String']['input'];
+  storeId: Types.Scalars['String']['input'];
+}>;
+
+export type ExamplePluginConfigurationQuery = {
+  __typename: 'Queries';
+  pluginData: {
+    __typename: 'PluginDataConnector';
+    nodes: Array<{
+      __typename: 'PluginDataNode';
+      id: string;
+      data: string;
+      storeId?: string | null;
+    }>;
+  };
+};
+
+export const ExamplePluginConfigurationDocument = gql`
+  query examplePluginConfiguration($pluginCode: String!, $storeId: String!) {
+    pluginData(
+      pluginCode: $pluginCode
+      storeId: $storeId
+      filter: { dataIdentifier: { equalTo: "configuration" } }
+    ) {
+      __typename
+      ... on PluginDataConnector {
+        nodes {
+          id
+          data
+          storeId
+        }
+      }
+    }
+  }
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper
+) {
+  return {
+    examplePluginConfiguration(
+      variables: ExamplePluginConfigurationQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<ExamplePluginConfigurationQuery> {
+      return withWrapper(
+        wrappedRequestHeaders =>
+          client.request<ExamplePluginConfigurationQuery>({
+            document: ExamplePluginConfigurationDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'examplePluginConfiguration',
+        'query',
+        variables
+      );
+    },
+  };
+}
+export type Sdk = ReturnType<typeof getSdk>;

--- a/frontend/latest/src/Configuration/operations.graphql
+++ b/frontend/latest/src/Configuration/operations.graphql
@@ -1,0 +1,19 @@
+query examplePluginConfiguration(
+  $pluginCode: String!
+  $storeId: String!
+) {
+  pluginData(
+    pluginCode: $pluginCode
+    storeId: $storeId
+    filter: { dataIdentifier: { equalTo: "configuration" } }
+  ) {
+    __typename
+    ... on PluginDataConnector {
+      nodes {
+        id
+        data
+        storeId
+      }
+    }
+  }
+}

--- a/frontend/latest/src/Configuration/types.ts
+++ b/frontend/latest/src/Configuration/types.ts
@@ -1,0 +1,9 @@
+export type ExamplePluginConfig = {
+  enabled: boolean;
+  logPrefix: string;
+};
+
+export const DEFAULT_EXAMPLE_PLUGIN_CONFIG: ExamplePluginConfig = {
+  enabled: true,
+  logPrefix: 'Example Plugins',
+};

--- a/frontend/latest/src/Configuration/usePluginConfiguration.ts
+++ b/frontend/latest/src/Configuration/usePluginConfiguration.ts
@@ -1,0 +1,58 @@
+import {
+  pluginConfigurationQueryKey,
+  useAuthContext,
+  useGql,
+  useQuery,
+} from '@openmsupply-client/common';
+import { name as pluginCode } from '../../package.json';
+import { getSdk } from './operations.generated';
+import {
+  DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+  ExamplePluginConfig,
+} from './types';
+
+// Reads this plugin's configuration row (the global one written from
+// Manage > Plugins). Falls back to the bundled defaults when no row exists.
+//
+// Cache shape (`{ id, data } | null`) MUST match the host's hook in
+// `system/Manage/Plugins/api/hooks/usePluginConfiguration.ts` because both
+// use the same query key — without that, whichever observer ran last would
+// poison the cache for the other. `select` projects the shared cache shape
+// down to the typed config the consumer wants.
+type CachedConfiguration = { id: string; data: unknown } | null;
+
+export const usePluginConfiguration = (): ExamplePluginConfig => {
+  const { client } = useGql();
+  const { storeId } = useAuthContext();
+  const sdk = getSdk(client);
+
+  const { data } = useQuery<
+    CachedConfiguration,
+    Error,
+    ExamplePluginConfig
+  >({
+    queryKey: pluginConfigurationQueryKey(pluginCode),
+    queryFn: async (): Promise<CachedConfiguration> => {
+      const result = await sdk.examplePluginConfiguration({
+        pluginCode,
+        storeId,
+      });
+      if (result.pluginData.__typename !== 'PluginDataConnector') return null;
+      const node = result.pluginData.nodes.find(n => n.storeId == null);
+      if (!node) return null;
+      let parsed: unknown = null;
+      try {
+        parsed = node.data ? JSON.parse(node.data) : null;
+      } catch {
+        parsed = null;
+      }
+      return { id: node.id, data: parsed };
+    },
+    select: cached => ({
+      ...DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+      ...((cached?.data ?? {}) as Partial<ExamplePluginConfig>),
+    }),
+  });
+
+  return data ?? DEFAULT_EXAMPLE_PLUGIN_CONFIG;
+};

--- a/frontend/latest/src/Dashboard/SyncStatusWidget.tsx
+++ b/frontend/latest/src/Dashboard/SyncStatusWidget.tsx
@@ -10,6 +10,7 @@ import {
   useTranslation,
 } from '@openmsupply-client/common';
 import { mapSyncError, useSync } from '@openmsupply-client/system';
+import { usePluginConfiguration } from '../Configuration';
 
 const FormattedSyncDate = ({ date }: { date: Date | null }) => {
   const t = useTranslation();
@@ -63,9 +64,18 @@ const Row: React.FC<PropsWithChildren<{ title: string }>> = ({
 const SyncStatusWidget = () => {
   const { syncStatus } = useSync.utils.syncInfo();
   const t = useTranslation();
+  const { enabled, logPrefix } = usePluginConfiguration();
 
+  if (!enabled) return null;
+
+  // NOTE: driving a user-visible title from a free-text plugin config is for
+  // demo purposes only. For real plugins, prefer adding the string to the
+  // plugin's translation files and looking it up by key — that way the title
+  // localises with the user's language instead of being a single fixed
+  // string. Configuration is the right home for behavioural toggles like
+  // `enabled`, not for translatable copy.
   return (
-    <Widget title={t('heading.synchronise-status')}>
+    <Widget title={logPrefix || t('heading.synchronise-status')}>
       <Grid
         container
         justifyContent="flex-start"

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -1,7 +1,6 @@
 import { Plugins, ReportsIcon } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
-import Replenishment from './Dashboard/Replenishment';
 import SyncStatus from './Dashboard/SyncStatus';
 import StockDonorEdit from './StockDonor/StockDonorEdit';
 import * as stockDonor from './StockDonor/StockDonorColumn';
@@ -9,11 +8,51 @@ import * as aggregateAmc from './AggregateAmc/AggregateAmcColumn';
 import { Info } from './AggregateAmc/AggregateAmcInfo';
 import { StockAgingPage } from './Pages/StockAgingPage';
 import { ReportingDailyPage } from './Pages/ReportingDailyPage';
+import {
+  DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+  ExamplePluginConfigComponent,
+} from './Configuration';
 
 const ReplenishmentAndSyncStatus: Plugins = {
+  // Plugin configuration UI surfaced from Manage > Plugins. A plugin provides
+  // either:
+  //   - `Component`: a custom React component (used here — see
+  //     ./Configuration/ConfigComponent.tsx). Full freedom over the UI.
+  //   - `jsonForms`: a `{ schema, uiSchema }` pair that the host renders with
+  //     the shared JSON Forms renderer. Less code; constrained to the
+  //     controls JSON Forms ships.
+  // The commented-out block below shows the JSON Forms equivalent of this
+  // plugin's config for plugin-author reference.
+  configuration: {
+    defaultConfig: DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+    Component: ExamplePluginConfigComponent,
+    // jsonForms: {
+    //   schema: {
+    //     type: 'object',
+    //     properties: {
+    //       enabled: { type: 'boolean', title: 'Show Sync Status widget' },
+    //       logPrefix: {
+    //         type: 'string',
+    //         title: 'Sync widget title',
+    //         description:
+    //           'Shown in the Sync Status dashboard widget and prefixed to ' +
+    //           'backend processor log lines.',
+    //       },
+    //     },
+    //     required: ['logPrefix'],
+    //   },
+    //   uiSchema: {
+    //     type: 'VerticalLayout',
+    //     elements: [
+    //       { type: 'Control', scope: '#/properties/enabled' },
+    //       { type: 'Control', scope: '#/properties/logPrefix' },
+    //     ],
+    //   },
+    // },
+  },
   inboundShipmentAppBar: [ShippingStatus],
   dashboard: {
-    widget: [{ Component: Replenishment }, { Component: SyncStatus }],
+    widget: [{ Component: SyncStatus }],
   },
   stockLine: {
     tableStateLoader: [stockDonor.StateLoader],

--- a/frontend/latest/src/plugin.tsx
+++ b/frontend/latest/src/plugin.tsx
@@ -1,4 +1,8 @@
-import { Plugins, ReportsIcon } from '@openmsupply-client/common';
+import {
+  Plugins,
+  PluginConfiguration,
+  ReportsIcon,
+} from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import ShippingStatus from './ShippingStatus/ShippingStatus';
 import SyncStatus from './Dashboard/SyncStatus';
@@ -10,46 +14,19 @@ import { StockAgingPage } from './Pages/StockAgingPage';
 import { ReportingDailyPage } from './Pages/ReportingDailyPage';
 import {
   DEFAULT_EXAMPLE_PLUGIN_CONFIG,
+  ExamplePluginConfig,
   ExamplePluginConfigComponent,
 } from './Configuration';
 
 const ReplenishmentAndSyncStatus: Plugins = {
-  // Plugin configuration UI surfaced from Manage > Plugins. A plugin provides
-  // either:
-  //   - `Component`: a custom React component (used here — see
-  //     ./Configuration/ConfigComponent.tsx). Full freedom over the UI.
-  //   - `jsonForms`: a `{ schema, uiSchema }` pair that the host renders with
-  //     the shared JSON Forms renderer. Less code; constrained to the
-  //     controls JSON Forms ships.
-  // The commented-out block below shows the JSON Forms equivalent of this
-  // plugin's config for plugin-author reference.
+  // Plugin configuration UI surfaced from Manage > Plugins. The plugin provides
+  // a custom React `Component` (see ./Configuration/ConfigComponent.tsx) that
+  // edits its config via `value`/`onChange`, with full freedom over the UI.
+  // `defaultConfig` seeds the form when no config has been saved yet.
   configuration: {
     defaultConfig: DEFAULT_EXAMPLE_PLUGIN_CONFIG,
     Component: ExamplePluginConfigComponent,
-    // jsonForms: {
-    //   schema: {
-    //     type: 'object',
-    //     properties: {
-    //       enabled: { type: 'boolean', title: 'Show Sync Status widget' },
-    //       logPrefix: {
-    //         type: 'string',
-    //         title: 'Sync widget title',
-    //         description:
-    //           'Shown in the Sync Status dashboard widget and prefixed to ' +
-    //           'backend processor log lines.',
-    //       },
-    //     },
-    //     required: ['logPrefix'],
-    //   },
-    //   uiSchema: {
-    //     type: 'VerticalLayout',
-    //     elements: [
-    //       { type: 'Control', scope: '#/properties/enabled' },
-    //       { type: 'Control', scope: '#/properties/logPrefix' },
-    //     ],
-    //   },
-    // },
-  },
+  } satisfies PluginConfiguration<ExamplePluginConfig>,
   inboundShipmentAppBar: [ShippingStatus],
   dashboard: {
     widget: [{ Component: SyncStatus }],


### PR DESCRIPTION
## Summary

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7602c8ab-6f98-40b2-be89-f88c7cecd644" />

- Adds a `configuration` slot to this example plugin's bundle, exercising the new host-side support for plugin config UIs.
- Uses the **custom React `Component`** path; the equivalent **JSON Forms** `{ schema, uiSchema }` version is kept as a commented-out reference in `plugin.tsx` so plugin authors can compare both approaches at a glance.
- `SyncStatusWidget` now reads the config — toggling `enabled` hides the widget, `logPrefix` overrides its title — demonstrating that a frontend plugin can react **live** to config changes saved from Manage → Plugins (host and plugin share the same React Query cache via the `pluginConfigurationQueryKey` helper exported from `@openmsupply-client/common`).

## Dependencies

> ⚠️ Requires the host-side plugin configuration PR: [msupply-foundation/open-msupply#11804](https://github.com/msupply-foundation/open-msupply/pull/11804). Without it the `Plugins` type has no `configuration` slot, the `pluginConfigurationQueryKey` helper doesn't exist, and the example will not type-check.

This branch is based on `fix-for-tanstack-query-upgrade` (Carl's React Query / webpack update PR) — that should land first.

## Test plan

- [ ] Land the host-side `open-msupply` PR; run `yarn install` and `yarn generate` in the host repo.
- [ ] `yarn plugin install` from the host repo to upload the rebuilt bundle.
- [ ] Manage → Plugins → click `plugin_examples` (frontend row). Custom React modal opens with checkbox + text input + live preview.
- [ ] Untick the checkbox, save. Sync Status widget on the dashboard disappears without a page reload.
- [ ] Re-tick, change the title, save. Dashboard widget reappears with the new title, no reload.
- [ ] Reload the page; values persist (stored as a `plugin_data` row with `store_id = NULL`).
- [ ] Uncomment the `jsonForms` block in `plugin.tsx` and comment out `Component` instead; re-install. Modal renders the JSON Forms equivalent, same persisted data.