### PR TITLE
Add enqueue_email example to backend plugin

### DIFF
--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -121,6 +121,23 @@ const plugins: BackendPlugins = {
             name: row.name,
           })),
         };
+      // Demonstrates the backend `enqueue_email` global (open-msupply #12182).
+      // Triggered on demand via the plugin graphql endpoint so it's easy to test.
+      // The email is added to the queue; the central server's scheduled task is
+      // what actually sends it. Both bodies are sent as multipart/alternative,
+      // so we provide html_body and a plain text_body fallback.
+      case 'sendEmail': {
+        const { id } = enqueue_email({
+          to_address: input.toAddress,
+          subject: 'open-mSupply example plugin',
+          html_body: '<p>Hello from the <b>example backend plugin</b>.</p>',
+          text_body: 'Hello from the example backend plugin.',
+        });
+
+        log({ message: 'Example Plugins - email queued', emailId: id });
+
+        return { type: 'sendEmail', emailId: id };
+      }
       default:
         assertUnreachable(input);
     }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4,11 +4,13 @@ export type Graphql = {
         type: 'aggregateAmc';
         itemIds: string[];
       }
-    | { type: 'echo'; echo: string };
+    | { type: 'echo'; echo: string }
+    | { type: 'sendEmail'; toAddress: string };
   output:
     | {
         type: 'aggregateAmc';
         stats: { itemId: string; name: string; amc: number }[];
       }
-    | { type: 'echo'; echo: string };
+    | { type: 'echo'; echo: string }
+    | { type: 'sendEmail'; emailId: string };
 };


### PR DESCRIPTION
Example usage for the backend `enqueue_email` global added in open-msupply#12183 (issue open-msupply#12182).

## What this does
Adds a `sendEmail` case to the example plugin's `graphql_query` handler. It calls the new backend `enqueue_email` global and returns the queued email id. Exposing it through the plugin graphql endpoint makes it easy to trigger and test on demand (vs. the schedule/processor handlers which fire on timers/changelog).

- `shared/types.ts` — adds `sendEmail` to the `Graphql` input/output union.
- `backend/latest/src/plugin.ts` — handles the `sendEmail` case, supplying both `html_body` and `text_body` (the email is sent as multipart/alternative).
- `bundle.json` — rebuilt bundle.

## Notes
- Based on the `11949-schedule-fetch-example` branch (which adds the fetch example); retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)