### PR TITLE
chore: migrate processor filter to CompatibilityChangelogFilter

### DIFF
--- a/backend/latest/src/plugin.ts
+++ b/backend/latest/src/plugin.ts
@@ -2,7 +2,7 @@
 // cargo run --bin remote_server_cli -- generate-and-install-plugin-bundle -i '../client/packages/plugins/{plugin name}/backend' -u 'http://localhost:8000' --username 'test' --password 'pass'
 
 import { BackendPlugins } from '@common/types';
-import { ChangelogFilter } from '@common/generated/ChangelogFilter';
+import { CompatibilityChangelogFilter } from '@common/generated/CompatibilityChangelogFilter';
 import { sqlDateTime, sqlList, sqlQuery } from '@common/utils';
 import { Graphql } from '../../../shared/types';
 // Tree shaking working
@@ -127,7 +127,7 @@ const plugins: BackendPlugins = {
   processor: input => {
     switch (input.t) {
       case 'Filter': {
-        const filter: ChangelogFilter = {
+        const filter: CompatibilityChangelogFilter = {
           table_name: { equal_to: 'Invoice' },
         };
 


### PR DESCRIPTION
## What

Swap the example processor's changelog filter type from `ChangelogFilter` to `CompatibilityChangelogFilter`.

## Why

The open mSupply V7 sync rework changes the plugin-facing generated types:

- `ProcessorOutput`'s `Filter` variant now carries a `CompatibilityChangelogFilter` instead of `ChangelogFilter` (regenerated in msupply-foundation/open-msupply#12385).
- On the server, `ChangelogFilter` has been reduced to a fieldless query-builder namespace (no `#[derive(TS)]`), so `@common/generated/ChangelogFilter` will stop being generated in a future regen and the old import will then fail to resolve.

`CompatibilityChangelogFilter` was introduced specifically to keep existing plugins working — it is identical to the old `ChangelogFilter` minus the now-removed `name_id` field. As the canonical examples repo, this should demonstrate the current filter type so downstream plugins copy the right pattern.

## Compatibility

The example processor only filters on `table_name`, which exists in `CompatibilityChangelogFilter`, so behaviour is unchanged. This only matters when the plugin is rebuilt against a newer open mSupply.

## ⚠️ Blocked on open-msupply#12385

`@common/generated/CompatibilityChangelogFilter.ts` only exists once msupply-foundation/open-msupply#12385 merges (it is not yet on `develop` / `v3.0.0-RC`). Kept as a **draft** until that lands — mark ready for review once it does.

## Tested

- Mechanical type-name swap only; the filter object and its fields are unchanged.
- Static-checked that the field used (`table_name`) is present in `CompatibilityChangelogFilter`.
- Not build-verified yet: the new generated type isn't on any merged open mSupply branch, so the plugin can't be compiled against it until #12385 is merged.
